### PR TITLE
feat: add --by-model flag for model/provider breakdown

### DIFF
--- a/opencode-usage
+++ b/opencode-usage
@@ -19,6 +19,7 @@ Options:
   --cache-read-rate NUM     Cost per 1M cache read tokens
   --cache-write-rate NUM    Cost per 1M cache write tokens
   --currency SYMBOL         Currency symbol for cost output (default: $)
+  --by-model                Show token breakdown by model/provider per category
   --pretty                  Pretty-print output with box drawing and bars
   --help                    Show this help
 
@@ -207,6 +208,7 @@ DEFAULT_CATEGORY="other"
 declare -A CATEGORY_PREFIXES
 CATEGORY_NAMES=()
 PRETTY=false
+BY_MODEL=false
 
 INPUT_RATE=""
 OUTPUT_RATE=""
@@ -272,6 +274,10 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--pretty)
 			PRETTY=true
+			shift
+			;;
+		--by-model)
+			BY_MODEL=true
 			shift
 			;;
 		--help|-h)
@@ -460,6 +466,35 @@ order by bucket;
 "
 fi
 
+MODEL_QUERY=""
+if [[ "$BY_MODEL" == true ]]; then
+	MODEL_QUERY="
+select '---MODELS';
+select c.bucket || char(9) ||
+       coalesce(ms.provider || '/' || ms.model_id, 'unknown') || char(9) ||
+       sum(c.input_tokens) || char(9) ||
+       sum(c.output_tokens) || char(9) ||
+       sum(c.reasoning_tokens) || char(9) ||
+       sum(c.input_tokens + c.output_tokens + c.reasoning_tokens) || char(9) ||
+       count(distinct c.session_id) || char(9) ||
+       sum(c.message_count) || char(9) ||
+       round(100.0 * sum(c.input_tokens + c.output_tokens + c.reasoning_tokens) /
+         nullif(sum(sum(c.input_tokens + c.output_tokens + c.reasoning_tokens)) over (partition by c.bucket), 0), 1)
+from categorized c
+left join (
+  select session_id,
+         json_extract(data, '$.model.providerID') as provider,
+         json_extract(data, '$.model.modelID') as model_id,
+         row_number() over (partition by session_id order by count(*) desc) as rn
+  from message
+  where json_extract(data, '$.model.modelID') is not null
+  group by session_id, json_extract(data, '$.model.providerID'), json_extract(data, '$.model.modelID')
+) ms on ms.session_id = c.session_id and ms.rn = 1
+group by c.bucket, coalesce(ms.provider || '/' || ms.model_id, 'unknown')
+order by c.bucket, sum(c.input_tokens + c.output_tokens + c.reasoning_tokens) desc;
+"
+fi
+
 ALL_DATA=$(sqlite3 "$DB_PATH" "
 $MATERIALIZE_SQL
 
@@ -507,6 +542,8 @@ group by bucket
 order by sum(input_tokens+output_tokens+reasoning_tokens) desc;
 
 $COST_QUERY
+
+$MODEL_QUERY
 ")
 
 ## --- Parse the combined output into sections ---
@@ -515,6 +552,7 @@ OVERVIEW_DATA=""
 PCT_DATA=""
 SUMMARY_DATA=""
 COST_DATA=""
+MODEL_DATA=""
 declare -A PROJECT_DATA_MAP
 CURRENT_SECTION=""
 
@@ -525,6 +563,7 @@ while IFS= read -r line; do
 		---PROJECTS:*) CURRENT_SECTION="projects:${line#---PROJECTS:}"; continue ;;
 		---SUMMARY) CURRENT_SECTION="summary"; continue ;;
 		---COST) CURRENT_SECTION="cost"; continue ;;
+		---MODELS) CURRENT_SECTION="models"; continue ;;
 	esac
 	case "$CURRENT_SECTION" in
 		overview)
@@ -549,6 +588,10 @@ while IFS= read -r line; do
 		cost)
 			[[ -n "$COST_DATA" ]] && COST_DATA+=$'\n'
 			COST_DATA+="$line"
+			;;
+		models)
+			[[ -n "$MODEL_DATA" ]] && MODEL_DATA+=$'\n'
+			MODEL_DATA+="$line"
 			;;
 	esac
 done <<< "$ALL_DATA"
@@ -655,6 +698,31 @@ if [[ -n "$COST_DATA" ]]; then
 		printf '\nCost estimate (%s per 1M tokens)\n' "$CURRENCY"
 		printf '%s\n' "$COST_DATA" | (
 			printf 'bucket\tcost\n'
+			cat
+		) | format_table
+	fi
+fi
+
+if [[ -n "$MODEL_DATA" ]]; then
+	if [[ "$PRETTY" == true ]]; then
+		section_header "Model Breakdown"
+		local_last_bucket=""
+		while IFS=$'\t' read -r bucket model input_tok output_tok reasoning_tok total_tok sessions messages pct; do
+			if [[ "$bucket" != "$local_last_bucket" ]]; then
+				printf '\n  %s%s%s\n' "$BOLD" "$bucket" "$RESET"
+				printf '  %-35s %10s %10s %18s %7s\n' \
+					"${DIM}Model${RESET}" "${DIM}Sessions${RESET}" "${DIM}Messages${RESET}" "${DIM}Tokens${RESET}" "${DIM}   %${RESET}"
+				local_last_bucket="$bucket"
+			fi
+			printf '  %-35s %10s %10s %18s %6s%%\n' \
+				"$model" "$(format_number "$sessions")" "$(format_number "$messages")" \
+				"$(format_number "$total_tok")" "$pct"
+		done <<< "$MODEL_DATA"
+		printf '\n'
+	else
+		printf '\nModel breakdown\n'
+		printf '%s\n' "$MODEL_DATA" | (
+			printf 'bucket\tmodel\tinput_tokens\toutput_tokens\treasoning_tokens\ttotal_tokens\tsessions\tmessages\tpct\n'
 			cat
 		) | format_table
 	fi


### PR DESCRIPTION
## Summary
- Adds `--by-model` flag that shows token usage broken down by model and provider for each category
- Queries `message.data` for `$.model.providerID` and `$.model.modelID` fields
- Renders as a ranked table per category in both plain and pretty modes

Closes #1