### PR TITLE
feat: add --tools flag for tool usage statistics

### DIFF
--- a/opencode-usage
+++ b/opencode-usage
@@ -19,6 +19,7 @@ Options:
   --cache-read-rate NUM     Cost per 1M cache read tokens
   --cache-write-rate NUM    Cost per 1M cache write tokens
   --currency SYMBOL         Currency symbol for cost output (default: $)
+  --tools                   Show tool usage breakdown per category
   --pretty                  Pretty-print output with box drawing and bars
   --help                    Show this help
 
@@ -207,6 +208,7 @@ DEFAULT_CATEGORY="other"
 declare -A CATEGORY_PREFIXES
 CATEGORY_NAMES=()
 PRETTY=false
+SHOW_TOOLS=false
 
 INPUT_RATE=""
 OUTPUT_RATE=""
@@ -272,6 +274,10 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--pretty)
 			PRETTY=true
+			shift
+			;;
+		--tools)
+			SHOW_TOOLS=true
 			shift
 			;;
 		--help|-h)
@@ -460,6 +466,25 @@ order by bucket;
 "
 fi
 
+TOOLS_QUERY=""
+if [[ "$SHOW_TOOLS" == true ]]; then
+	TOOLS_QUERY="
+select '---TOOLS';
+select c.bucket || char(9) ||
+       coalesce(json_extract(p.data, '$.tool'), 'unknown') || char(9) ||
+       count(*) || char(9) ||
+       round(100.0 * count(*) /
+         nullif(sum(count(*)) over (partition by c.bucket), 0), 1)
+from categorized c
+join part p on p.session_id = c.session_id
+where json_extract(p.data, '$.type') = 'tool'
+  and p.time_created >= (strftime('%s','$MONTH_START')*1000)
+  and p.time_created < (strftime('%s','$MONTH_END')*1000)
+group by c.bucket, coalesce(json_extract(p.data, '$.tool'), 'unknown')
+order by c.bucket, count(*) desc;
+"
+fi
+
 ALL_DATA=$(sqlite3 "$DB_PATH" "
 $MATERIALIZE_SQL
 
@@ -507,6 +532,8 @@ group by bucket
 order by sum(input_tokens+output_tokens+reasoning_tokens) desc;
 
 $COST_QUERY
+
+$TOOLS_QUERY
 ")
 
 ## --- Parse the combined output into sections ---
@@ -515,6 +542,7 @@ OVERVIEW_DATA=""
 PCT_DATA=""
 SUMMARY_DATA=""
 COST_DATA=""
+TOOLS_DATA=""
 declare -A PROJECT_DATA_MAP
 CURRENT_SECTION=""
 
@@ -525,6 +553,7 @@ while IFS= read -r line; do
 		---PROJECTS:*) CURRENT_SECTION="projects:${line#---PROJECTS:}"; continue ;;
 		---SUMMARY) CURRENT_SECTION="summary"; continue ;;
 		---COST) CURRENT_SECTION="cost"; continue ;;
+		---TOOLS) CURRENT_SECTION="tools"; continue ;;
 	esac
 	case "$CURRENT_SECTION" in
 		overview)
@@ -549,6 +578,10 @@ while IFS= read -r line; do
 		cost)
 			[[ -n "$COST_DATA" ]] && COST_DATA+=$'\n'
 			COST_DATA+="$line"
+			;;
+		tools)
+			[[ -n "$TOOLS_DATA" ]] && TOOLS_DATA+=$'\n'
+			TOOLS_DATA+="$line"
 			;;
 	esac
 done <<< "$ALL_DATA"
@@ -655,6 +688,30 @@ if [[ -n "$COST_DATA" ]]; then
 		printf '\nCost estimate (%s per 1M tokens)\n' "$CURRENCY"
 		printf '%s\n' "$COST_DATA" | (
 			printf 'bucket\tcost\n'
+			cat
+		) | format_table
+	fi
+fi
+
+if [[ -n "$TOOLS_DATA" ]]; then
+	if [[ "$PRETTY" == true ]]; then
+		section_header "Tool Usage"
+		local_last_bucket=""
+		while IFS=$'\t' read -r bucket tool_name call_count pct; do
+			if [[ "$bucket" != "$local_last_bucket" ]]; then
+				printf '\n  %s%s%s\n' "$BOLD" "$bucket" "$RESET"
+				printf '  %-25s %10s %7s\n' \
+					"${DIM}Tool${RESET}" "${DIM}Calls${RESET}" "${DIM}   %${RESET}"
+				local_last_bucket="$bucket"
+			fi
+			printf '  %-25s %10s %6s%%\n' \
+				"$tool_name" "$(format_number "$call_count")" "$pct"
+		done <<< "$TOOLS_DATA"
+		printf '\n'
+	else
+		printf '\nTool usage\n'
+		printf '%s\n' "$TOOLS_DATA" | (
+			printf 'bucket\ttool\tcalls\tpct\n'
 			cat
 		) | format_table
 	fi


### PR DESCRIPTION
## Summary
- Adds `--tools` flag that shows which tools (file edits, bash, grep, etc.) are used most per category
- Extracts tool names from `part.data` at `$.tool` for tool-type parts
- Ranks tools by invocation count with both plain and pretty output

Closes #3