### PR TITLE
feat: add --diff-stats flag for git diff statistics

### DIFF
--- a/opencode-usage
+++ b/opencode-usage
@@ -19,6 +19,7 @@ Options:
   --cache-read-rate NUM     Cost per 1M cache read tokens
   --cache-write-rate NUM    Cost per 1M cache write tokens
   --currency SYMBOL         Currency symbol for cost output (default: $)
+  --diff-stats              Show lines of code added/deleted per category
   --pretty                  Pretty-print output with box drawing and bars
   --help                    Show this help
 
@@ -207,6 +208,7 @@ DEFAULT_CATEGORY="other"
 declare -A CATEGORY_PREFIXES
 CATEGORY_NAMES=()
 PRETTY=false
+SHOW_DIFF_STATS=false
 
 INPUT_RATE=""
 OUTPUT_RATE=""
@@ -272,6 +274,10 @@ while [[ $# -gt 0 ]]; do
 			;;
 		--pretty)
 			PRETTY=true
+			shift
+			;;
+		--diff-stats)
+			SHOW_DIFF_STATS=true
 			shift
 			;;
 		--help|-h)
@@ -460,6 +466,22 @@ order by bucket;
 "
 fi
 
+DIFF_STATS_QUERY=""
+if [[ "$SHOW_DIFF_STATS" == true ]]; then
+	DIFF_STATS_QUERY="
+select '---DIFFSTATS';
+select c.bucket || char(9) ||
+       coalesce(sum(s.summary_additions), 0) || char(9) ||
+       coalesce(sum(s.summary_deletions), 0) || char(9) ||
+       coalesce(sum(s.summary_files), 0) || char(9) ||
+       count(distinct case when coalesce(s.summary_additions,0) > 0 or coalesce(s.summary_deletions,0) > 0 then c.session_id end)
+from categorized c
+join session s on s.id = c.session_id
+group by c.bucket
+order by c.bucket;
+"
+fi
+
 ALL_DATA=$(sqlite3 "$DB_PATH" "
 $MATERIALIZE_SQL
 
@@ -507,6 +529,8 @@ group by bucket
 order by sum(input_tokens+output_tokens+reasoning_tokens) desc;
 
 $COST_QUERY
+
+$DIFF_STATS_QUERY
 ")
 
 ## --- Parse the combined output into sections ---
@@ -515,6 +539,7 @@ OVERVIEW_DATA=""
 PCT_DATA=""
 SUMMARY_DATA=""
 COST_DATA=""
+DIFF_STATS_DATA=""
 declare -A PROJECT_DATA_MAP
 CURRENT_SECTION=""
 
@@ -525,6 +550,7 @@ while IFS= read -r line; do
 		---PROJECTS:*) CURRENT_SECTION="projects:${line#---PROJECTS:}"; continue ;;
 		---SUMMARY) CURRENT_SECTION="summary"; continue ;;
 		---COST) CURRENT_SECTION="cost"; continue ;;
+		---DIFFSTATS) CURRENT_SECTION="diffstats"; continue ;;
 	esac
 	case "$CURRENT_SECTION" in
 		overview)
@@ -549,6 +575,10 @@ while IFS= read -r line; do
 		cost)
 			[[ -n "$COST_DATA" ]] && COST_DATA+=$'\n'
 			COST_DATA+="$line"
+			;;
+		diffstats)
+			[[ -n "$DIFF_STATS_DATA" ]] && DIFF_STATS_DATA+=$'\n'
+			DIFF_STATS_DATA+="$line"
 			;;
 	esac
 done <<< "$ALL_DATA"
@@ -655,6 +685,33 @@ if [[ -n "$COST_DATA" ]]; then
 		printf '\nCost estimate (%s per 1M tokens)\n' "$CURRENCY"
 		printf '%s\n' "$COST_DATA" | (
 			printf 'bucket\tcost\n'
+			cat
+		) | format_table
+	fi
+fi
+
+if [[ -n "$DIFF_STATS_DATA" ]]; then
+	if [[ "$PRETTY" == true ]]; then
+		section_header "Code Impact (Git Diff Stats)"
+		printf '\n'
+		printf '  %-14s %12s %12s %12s %10s\n' \
+			"${BOLD}Category${RESET}" "${BOLD}${GREEN}+Added${RESET}" "${BOLD}${YELLOW}-Deleted${RESET}" "${BOLD}Net${RESET}" "${BOLD}Files${RESET}"
+		printf '  %-14s %12s %12s %12s %10s\n' \
+			"──────────────" "────────────" "────────────" "────────────" "──────────"
+		while IFS=$'\t' read -r bucket additions deletions files sessions_with; do
+			local_net=$(( additions - deletions ))
+			printf '  %-14s %s%12s%s %s%12s%s %12s %10s\n' \
+				"$bucket" \
+				"$GREEN" "+$(format_number "$additions")" "$RESET" \
+				"$YELLOW" "-$(format_number "$deletions")" "$RESET" \
+				"$(format_number "$local_net")" \
+				"$(format_number "$files")"
+		done <<< "$DIFF_STATS_DATA"
+		printf '\n'
+	else
+		printf '\nCode impact (git diff stats)\n'
+		printf '%s\n' "$DIFF_STATS_DATA" | (
+			printf 'bucket\tadditions\tdeletions\tfiles\tsessions_with_changes\n'
 			cat
 		) | format_table
 	fi


### PR DESCRIPTION
## Summary
- Adds `--diff-stats` flag showing lines added/deleted and files changed per category
- Uses `session.summary_additions`, `summary_deletions`, and `summary_files` columns
- Shows net change and per-session averages in both output modes

Closes #4