### PR TITLE
feat: add --todos flag for task/todo completion statistics

### DIFF
--- a/opencode-usage
+++ b/opencode-usage
@@ -19,6 +19,7 @@ Options:
   --cache-read-rate NUM     Cost per 1M cache read tokens
   --cache-write-rate NUM    Cost per 1M cache write tokens
   --currency SYMBOL         Currency symbol for cost output (default: $)
+  --todos                   Show todo/task completion statistics
   --pretty                  Pretty-print output with box drawing and bars
   --help                    Show this help
 
@@ -207,6 +208,7 @@ DEFAULT_CATEGORY="other"
 declare -A CATEGORY_PREFIXES
 CATEGORY_NAMES=()
 PRETTY=false
+SHOW_TODOS=false
 
 INPUT_RATE=""
 OUTPUT_RATE=""
@@ -269,6 +271,10 @@ while [[ $# -gt 0 ]]; do
 		--currency)
 			CURRENCY=$2
 			shift 2
+			;;
+		--todos)
+			SHOW_TODOS=true
+			shift
 			;;
 		--pretty)
 			PRETTY=true
@@ -460,6 +466,37 @@ order by bucket;
 "
 fi
 
+# Build todo stats query if requested
+TODO_QUERY=""
+if [[ "$SHOW_TODOS" == true ]]; then
+	TODO_QUERY="
+select '---TODOS_STATUS';
+select c.bucket || char(9) ||
+       t.status || char(9) ||
+       count(*)
+from categorized c
+join todo t on t.session_id = c.session_id
+group by c.bucket, t.status
+order by c.bucket, t.status;
+
+select '---TODOS_PRIORITY';
+select c.bucket || char(9) ||
+       t.priority || char(9) ||
+       count(*)
+from categorized c
+join todo t on t.session_id = c.session_id
+group by c.bucket, t.priority
+order by c.bucket,
+  case t.priority
+    when 'critical' then 1
+    when 'high' then 2
+    when 'medium' then 3
+    when 'low' then 4
+    else 5
+  end;
+"
+fi
+
 ALL_DATA=$(sqlite3 "$DB_PATH" "
 $MATERIALIZE_SQL
 
@@ -507,6 +544,8 @@ group by bucket
 order by sum(input_tokens+output_tokens+reasoning_tokens) desc;
 
 $COST_QUERY
+
+$TODO_QUERY
 ")
 
 ## --- Parse the combined output into sections ---
@@ -515,6 +554,8 @@ OVERVIEW_DATA=""
 PCT_DATA=""
 SUMMARY_DATA=""
 COST_DATA=""
+TODOS_STATUS_DATA=""
+TODOS_PRIORITY_DATA=""
 declare -A PROJECT_DATA_MAP
 CURRENT_SECTION=""
 
@@ -525,6 +566,8 @@ while IFS= read -r line; do
 		---PROJECTS:*) CURRENT_SECTION="projects:${line#---PROJECTS:}"; continue ;;
 		---SUMMARY) CURRENT_SECTION="summary"; continue ;;
 		---COST) CURRENT_SECTION="cost"; continue ;;
+		---TODOS_STATUS) CURRENT_SECTION="todos_status"; continue ;;
+		---TODOS_PRIORITY) CURRENT_SECTION="todos_priority"; continue ;;
 	esac
 	case "$CURRENT_SECTION" in
 		overview)
@@ -549,6 +592,14 @@ while IFS= read -r line; do
 		cost)
 			[[ -n "$COST_DATA" ]] && COST_DATA+=$'\n'
 			COST_DATA+="$line"
+			;;
+		todos_status)
+			[[ -n "$TODOS_STATUS_DATA" ]] && TODOS_STATUS_DATA+=$'\n'
+			TODOS_STATUS_DATA+="$line"
+			;;
+		todos_priority)
+			[[ -n "$TODOS_PRIORITY_DATA" ]] && TODOS_PRIORITY_DATA+=$'\n'
+			TODOS_PRIORITY_DATA+="$line"
 			;;
 	esac
 done <<< "$ALL_DATA"
@@ -655,6 +706,117 @@ if [[ -n "$COST_DATA" ]]; then
 		printf '\nCost estimate (%s per 1M tokens)\n' "$CURRENCY"
 		printf '%s\n' "$COST_DATA" | (
 			printf 'bucket\tcost\n'
+			cat
+		) | format_table
+	fi
+fi
+
+if [[ -n "$TODOS_STATUS_DATA" ]]; then
+	# Build a map: bucket -> {status: count, ...}
+	declare -A TODO_STATUS_MAP
+	ALL_STATUSES=()
+	declare -A STATUS_SEEN
+
+	while IFS=$'\t' read -r bucket status count; do
+		TODO_STATUS_MAP["$bucket|$status"]=$count
+		if [[ -z "${STATUS_SEEN[$status]+x}" ]]; then
+			STATUS_SEEN[$status]=1
+			ALL_STATUSES+=("$status")
+		fi
+	done <<< "$TODOS_STATUS_DATA"
+
+	if [[ "$PRETTY" == true ]]; then
+		section_header "Todo Status by Category"
+		printf '\n'
+		# Header
+		local_fmt="  %-14s"
+		printf "$local_fmt" "${BOLD}Category${RESET}"
+		for s in "${ALL_STATUSES[@]}"; do
+			printf ' %12s' "${BOLD}${s}${RESET}"
+		done
+		printf ' %12s\n' "${BOLD}total${RESET}"
+		printf "$local_fmt" "──────────────"
+		for s in "${ALL_STATUSES[@]}"; do
+			printf ' %12s' "────────────"
+		done
+		printf ' %12s\n' "────────────"
+
+		for bucket in "${BUCKETS[@]}"; do
+			printf "$local_fmt" "$bucket"
+			local_total=0
+			for s in "${ALL_STATUSES[@]}"; do
+				local_val=${TODO_STATUS_MAP["$bucket|$s"]:-0}
+				printf ' %12s' "$(format_number "$local_val")"
+				(( local_total += local_val ))
+			done
+			printf ' %12s\n' "$(format_number "$local_total")"
+		done
+
+		# Completion rate
+		printf '\n'
+		for bucket in "${BUCKETS[@]}"; do
+			local_completed=${TODO_STATUS_MAP["$bucket|completed"]:-0}
+			local_total=0
+			for s in "${ALL_STATUSES[@]}"; do
+				(( local_total += ${TODO_STATUS_MAP["$bucket|$s"]:-0} ))
+			done
+			if (( local_total > 0 )); then
+				local_pct=$(( local_completed * 100 / local_total ))
+				printf '  %-14s completion: %s %d%%\n' "$bucket" "$(make_bar "$local_pct")" "$local_pct"
+			fi
+		done
+		printf '\n'
+	else
+		printf '\nTodo status by category\n'
+		printf '%s\n' "$TODOS_STATUS_DATA" | (
+			printf 'bucket\tstatus\tcount\n'
+			cat
+		) | format_table
+	fi
+fi
+
+if [[ -n "$TODOS_PRIORITY_DATA" ]]; then
+	if [[ "$PRETTY" == true ]]; then
+		section_header "Todo Priority by Category"
+		printf '\n'
+
+		declare -A TODO_PRIORITY_MAP
+		ALL_PRIORITIES=()
+		declare -A PRIORITY_SEEN
+
+		while IFS=$'\t' read -r bucket priority count; do
+			TODO_PRIORITY_MAP["$bucket|$priority"]=$count
+			if [[ -z "${PRIORITY_SEEN[$priority]+x}" ]]; then
+				PRIORITY_SEEN[$priority]=1
+				ALL_PRIORITIES+=("$priority")
+			fi
+		done <<< "$TODOS_PRIORITY_DATA"
+
+		local_fmt="  %-14s"
+		printf "$local_fmt" "${BOLD}Category${RESET}"
+		for p in "${ALL_PRIORITIES[@]}"; do
+			printf ' %10s' "${BOLD}${p}${RESET}"
+		done
+		printf '\n'
+		printf "$local_fmt" "──────────────"
+		for p in "${ALL_PRIORITIES[@]}"; do
+			printf ' %10s' "──────────"
+		done
+		printf '\n'
+
+		for bucket in "${BUCKETS[@]}"; do
+			printf "$local_fmt" "$bucket"
+			for p in "${ALL_PRIORITIES[@]}"; do
+				local_val=${TODO_PRIORITY_MAP["$bucket|$p"]:-0}
+				printf ' %10s' "$(format_number "$local_val")"
+			done
+			printf '\n'
+		done
+		printf '\n'
+	else
+		printf '\nTodo priority by category\n'
+		printf '%s\n' "$TODOS_PRIORITY_DATA" | (
+			printf 'bucket\tpriority\tcount\n'
 			cat
 		) | format_table
 	fi


### PR DESCRIPTION
## Summary
- Adds `--todos` flag showing todo item statistics from OpenCode's todo table
- Per-category breakdown of todo statuses (completed, pending, in_progress, cancelled) with completion rate bars
- Priority distribution (critical, high, medium, low) per category

Closes #8